### PR TITLE
counterclockwise rotation

### DIFF
--- a/Falling Bricks/Game.c
+++ b/Falling Bricks/Game.c
@@ -76,6 +76,7 @@ struct Flags {
 	bool move_player_left;
 	bool move_player_right;
 	bool rotate_player;
+	bool clockwise_rotation;
 	bool drop_player;
 	bool pause;
 	bool check_full_rows;
@@ -313,8 +314,13 @@ void process_input(bool* running) {
 		else if (key == SDLK_p) {
 			flags.pause = !flags.pause;
 		}
-		else if (key == SDLK_UP) {
+		else if (key == SDLK_UP || key == SDLK_x) {
 			flags.rotate_player = true;
+			flags.clockwise_rotation = true;
+		}
+		else if (key == SDLK_z) {
+			flags.rotate_player = true;
+			flags.clockwise_rotation = false;
 		}
 		else if (key == SDLK_DOWN) {
 			flags.move_player_down = true;
@@ -437,7 +443,7 @@ void update() {
 			flags.move_player_right = false;
 		}
 		if (flags.rotate_player) {
-			Piece* rotated_piece = try_rotate_piece(game_board, player_piece);
+			Piece* rotated_piece = try_rotate_piece(game_board, player_piece, flags.clockwise_rotation);
 			if (rotated_piece) {
 				destroy_piece(player_piece);
 				// Update to rotated piece and new position after rotation

--- a/Falling Bricks/Grid.c
+++ b/Falling Bricks/Grid.c
@@ -153,8 +153,8 @@ static bool drop_piece_on_grid(Grid* grid, Piece* piece, bool lock) {
 }
 
 // Also returns new row and column position for center rotation
-Piece* try_rotate_piece(Grid* grid, Piece* piece) {
-	Piece* rotated_piece = rotate_piece(piece);
+Piece* try_rotate_piece(Grid* grid, Piece* piece, bool clockwise) {
+	Piece* rotated_piece = rotate_piece(piece, clockwise);
 	if (!rotated_piece) {
 		return NULL;
 	}

--- a/Falling Bricks/Grid.h
+++ b/Falling Bricks/Grid.h
@@ -35,7 +35,7 @@ bool add_piece_to_grid(Grid* grid, Piece* piece, bool lock, bool drop);
 
 void mark_x_cells(Grid* grid, Piece* piece);
 
-Piece* try_rotate_piece(Grid* grid, Piece* piece);
+Piece* try_rotate_piece(Grid* grid, Piece* piece, bool clockwise);
 
 void clear_unlocked_cells(Grid* grid);
 

--- a/Falling Bricks/Piece.c
+++ b/Falling Bricks/Piece.c
@@ -112,7 +112,7 @@ Piece* create_piece(enum PieceType type) {
 	return piece;
 }
 
-Piece* rotate_piece(const Piece* piece) {
+Piece* rotate_piece(const Piece* piece, bool clockwise) {
 	Piece* rotated_piece = malloc(sizeof(Piece));
 
 	if (!rotated_piece) {
@@ -130,7 +130,9 @@ Piece* rotate_piece(const Piece* piece) {
 
 	for (int i = 0; i < new_width; i++) {
 		for (int j = 0; j < new_height; j++) {
-			rotated_piece->shape[j * new_width + (new_width - 1 - i)] = piece->shape[i * piece->width + j];
+			int col = clockwise ? new_width - 1 - i : i; // clockwise or counter-clockwise. In other words, start from the last col or first col
+			int row = clockwise ? j : new_height - 1 - j; // clockwise or counter-clockwise. In other words, start from the first row or last row
+			rotated_piece->shape[row * new_width + col] = piece->shape[i * piece->width + j];
 			// shape[j][new_width - 1 - i] = piece->shape[i][j];
 		}
 	}

--- a/Falling Bricks/Piece.h
+++ b/Falling Bricks/Piece.h
@@ -26,7 +26,7 @@ typedef struct {
 
 Piece* create_piece(enum PieceType type);
 
-Piece* rotate_piece(const Piece* piece);
+Piece* rotate_piece(const Piece* piece, bool clockwise);
 
 bool is_piece_empty(const Piece* piece);
 


### PR DESCRIPTION
closes #20

This pull request introduces support for both clockwise and counter-clockwise rotation of game pieces in the "Falling Bricks" game. The changes include updates to the input handling, rotation logic, and function signatures to accommodate this new feature.

### Input Handling Enhancements:
* Updated `process_input` in `Falling Bricks/Game.c` to map the `UP` or `X` keys to clockwise rotation and the `Z` key to counter-clockwise rotation. A new `clockwise_rotation` flag was added to the `Flags` struct to track the rotation direction. [[1]](diffhunk://#diff-70d451e9fd9fd1bac15ac43338c141e796ac3134168e63516034d312ee366537R79) [[2]](diffhunk://#diff-70d451e9fd9fd1bac15ac43338c141e796ac3134168e63516034d312ee366537L316-R323)

### Rotation Logic Updates:
* Modified the `rotate_piece` function in `Falling Bricks/Piece.c` to handle both clockwise and counter-clockwise rotations by adjusting the row and column calculations based on the `clockwise` parameter. [[1]](diffhunk://#diff-01eb1de674a8b48b9baf8cac12d0edcf8acdfc2ba7014b475ba0cc32fbd3512dL115-R115) [[2]](diffhunk://#diff-01eb1de674a8b48b9baf8cac12d0edcf8acdfc2ba7014b475ba0cc32fbd3512dL133-R135)
* Updated the `try_rotate_piece` function in `Falling Bricks/Grid.c` to pass the `clockwise` parameter to `rotate_piece`.

### Function Signature Changes:
* Updated function declarations in `Falling Bricks/Grid.h` and `Falling Bricks/Piece.h` to include the new `clockwise` parameter for `try_rotate_piece` and `rotate_piece`. [[1]](diffhunk://#diff-cfccadd7114f8ff798be342fa339a5bb4e83238cc5a64c76b906c7a292c5873eL38-R38) [[2]](diffhunk://#diff-ebcf732c35e1615322b023d36e4b99174d30eb1970f0e9d084ee59b2dd387ec0L29-R29)

### Game Logic Adjustment:
* Updated the `update` function in `Falling Bricks/Game.c` to pass the `clockwise_rotation` flag when calling `try_rotate_piece`.