### PR TITLE
Web assembly support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Web assembly build folder
+build

--- a/.gitignore
+++ b/.gitignore
@@ -363,4 +363,4 @@ MigrationBackup/
 FodyWeavers.xsd
 
 # Web assembly build folder
-build
+emcc_build

--- a/Falling Bricks/emcc_build.ps1
+++ b/Falling Bricks/emcc_build.ps1
@@ -1,0 +1,19 @@
+$emsdkPath = "D:\emscripten\emsdk" 
+. "$emsdkPath\emsdk_env.ps1"
+
+# Set the source directory and output directory
+$sourceFiles = Get-ChildItem -Path "source" -Filter "*.c" | ForEach-Object { $_.FullName }
+$outputDir = "build\index.html"
+
+# Run the emcc command to compile to WebAssembly
+emcc $sourceFiles -o $outputDir `
+    -s USE_SDL=2 `
+    -s USE_SDL_TTF=2 `
+    -s USE_SDL_MIXER=2 `
+    -s SDL2_MIXER_FORMATS='["mp3", "wav"]' `
+    -s ALLOW_MEMORY_GROWTH=1 `
+    -s ASSERTIONS=1 `
+    --preload-file assets `
+    -Iinclude `
+    -O2 `
+    -Wno-incompatible-pointer-types

--- a/Falling Bricks/emcc_build.ps1
+++ b/Falling Bricks/emcc_build.ps1
@@ -1,12 +1,28 @@
-$emsdkPath = "D:\emscripten\emsdk" 
-. "$emsdkPath\emsdk_env.ps1"
+# Check if running in GitHub Actions
+$inCI = $env:GITHUB_ACTIONS -eq "true"
 
-# Set the source directory and output directory
+if ($inCI) {
+    Write-Host "Running in GitHub Actions environment..."
+} else {
+    Write-Host "Running locally..."
+
+    # Set the local path for emsdk
+    $emsdkPath = "D:\emscripten\emsdk" 
+    . "$emsdkPath\emsdk_env.ps1"
+}
+
+# Define directories
 $sourceFiles = Get-ChildItem -Path "source" -Filter "*.c" | ForEach-Object { $_.FullName }
-$outputDir = "build\index.html"
+$outputDir = "emcc_build"
+$outputFile = "$outputDir\index.html"
+
+# Create the output directory if it doesn't exist
+if (!(Test-Path $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir
+}
 
 # Run the emcc command to compile to WebAssembly
-emcc $sourceFiles -o $outputDir `
+emcc $sourceFiles -o $outputFile `
     -s USE_SDL=2 `
     -s USE_SDL_TTF=2 `
     -s USE_SDL_MIXER=2 `

--- a/Falling Bricks/source/Grid.c
+++ b/Falling Bricks/source/Grid.c
@@ -366,6 +366,7 @@ static bool allocate_cells(Grid* grid) {
 		}
 		init_cells_in_row(grid->cells[i], grid->width);
 	}
+	return true;
 }
 
 static void deallocate_cells(Cell** cells, int height) {

--- a/Falling Bricks/source/Main.c
+++ b/Falling Bricks/source/Main.c
@@ -19,7 +19,7 @@ bool game_is_running = false;
 
 bool init_window(SDL_Window** window, SDL_Renderer** renderer) {
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) != 0) {
-		fprintf(stderr, "Error intitializing SDL.\n");
+		fprintf(stderr, "Error initializing SDL.\n");
 		return false;
 	}
 	SDL_Window* new_window = SDL_CreateWindow(

--- a/Falling Bricks/source/Menu.c
+++ b/Falling Bricks/source/Menu.c
@@ -83,7 +83,7 @@ struct TitleMenu* create_title_menu(ButtonCallback on_click[4]) {
 		free(menu);
 		return NULL;
 	}
-	create_grid_piece(menu);
+	//create_grid_piece(menu);
 
 	FontContext* font_context = get_font_context();
 	TTF_Font* title_font = font_context->title_font;

--- a/Falling Bricks/source/Menu.c
+++ b/Falling Bricks/source/Menu.c
@@ -83,7 +83,6 @@ struct TitleMenu* create_title_menu(ButtonCallback on_click[4]) {
 		free(menu);
 		return NULL;
 	}
-	//create_grid_piece(menu);
 
 	FontContext* font_context = get_font_context();
 	TTF_Font* title_font = font_context->title_font;


### PR DESCRIPTION
To run in a browser
closes #39 

This pull request introduces support for WebAssembly compilation and browser execution for the Falling Bricks game. Key changes include adding a build script for WebAssembly, modifying the main game loop to support both browser and native environments, and making minor adjustments to the codebase for compatibility and cleanup.

### WebAssembly Support:
* [`Falling Bricks/emcc_build.ps1`](diffhunk://#diff-689a27cdb2a17dbdf84d4cde106927b89526bf3086e49ff1bb5eee5b9958bbdbR1-R35): Added a PowerShell script to compile the game to WebAssembly using `emcc`. The script handles both local and CI environments, sets up the build directories, and includes necessary SDL dependencies.
* [`Falling Bricks/source/Main.c`](diffhunk://#diff-2fb9310b42db3f1181266ac3b1cb684f4759e3ee23b679b40784e4f24278be18R11-R21): Added conditional compilation for WebAssembly using `__EMSCRIPTEN__`. Introduced a browser-specific game loop (`main_loop`) and integrated `emscripten_set_main_loop` for browser execution. [[1]](diffhunk://#diff-2fb9310b42db3f1181266ac3b1cb684f4759e3ee23b679b40784e4f24278be18R11-R21) [[2]](diffhunk://#diff-2fb9310b42db3f1181266ac3b1cb684f4759e3ee23b679b40784e4f24278be18R69-R97)

### Code Adjustments:
* [`Falling Bricks/source/Main.c`](diffhunk://#diff-2fb9310b42db3f1181266ac3b1cb684f4759e3ee23b679b40784e4f24278be18R11-R21): Updated `SDL_Init` to initialize only `SDL_INIT_VIDEO` and `SDL_INIT_AUDIO` instead of `SDL_INIT_EVERYTHING` for better resource management.
* [`Falling Bricks/source/Grid.c`](diffhunk://#diff-8a5864fae855a4adf7cc1c7b56273810b8910804cefc61ca753ba1e725ea2e7eR369): Fixed a missing `return true;` in the `allocate_cells` function to ensure proper function behavior.
* [`Falling Bricks/source/Menu.c`](diffhunk://#diff-01532e8fed842788768d9e2a6007c32242cfa499073ab39a34fcbbc3bf7cbcc5L86): Removed an unused call to `create_grid_piece` in the `create_title_menu` function for cleanup.