### PR TITLE
Line clear memory leak fix

### DIFF
--- a/Falling Bricks/source/Grid.c
+++ b/Falling Bricks/source/Grid.c
@@ -623,19 +623,37 @@ void drop_all_pieces(Grid* grid) {
 	destroy_dynamic_array(pieces_to_drop);
 
 
-	// Now go over each piece and see if it can drop further
-	for (int i = 0; i < grid->locked_pieces->size; i++) {
-		Piece* piece = get_from_dynamic_array(grid->locked_pieces, i);
-		set_lock(piece, grid, false);
-		clear_piece_pointers(grid, piece);
-		drop_piece_on_grid(grid, piece, true);
+	// Now go over each piece and see if it can drop further. While loop is for very rare cases where a piece can drop further after another piece has dropped.
+	bool can_drop_further = true;
+	while (can_drop_further) {
+		can_drop_further = false;
+		for (int i = 0; i < grid->locked_pieces->size; i++) {
+			Piece* piece = get_from_dynamic_array(grid->locked_pieces, i);
+			set_lock(piece, grid, false);
+			clear_piece_pointers(grid, piece);
+			drop_piece_on_grid(grid, piece, true);
+		}
+		// Check if any piece can drop further
+		for (int i = 0; i < grid->locked_pieces->size; i++) {
+			Piece* piece = get_from_dynamic_array(grid->locked_pieces, i);
+			set_lock(piece, grid, false);
+			if (validate_piece_at_position(grid, piece, piece->row_pos + 1, piece->col_pos)) {
+				set_lock(piece, grid, true);
+				can_drop_further = true;
+				break;
+			}
+			set_lock(piece, grid, true);
+		}
 	}
 
+	/// Debug check
 	// For each piece assert that it can't drop further
-	for (int i = 0; i < grid->locked_pieces->size; i++) {
-		Piece* piece = get_from_dynamic_array(grid->locked_pieces, i);
-		SDL_assert(!validate_piece_at_position(grid, piece, piece->row_pos + 1, piece->col_pos));
-	}
+	//for (int i = 0; i < grid->locked_pieces->size; i++) {
+	//	Piece* piece = get_from_dynamic_array(grid->locked_pieces, i);
+	//	set_lock(piece, grid, false);
+	//	SDL_assert(!validate_piece_at_position(grid, piece, piece->row_pos + 1, piece->col_pos));
+	//	set_lock(piece, grid, true);
+	//}
 
 }
 

--- a/Falling Bricks/source/Grid.c
+++ b/Falling Bricks/source/Grid.c
@@ -608,8 +608,6 @@ void drop_all_pieces(Grid* grid) {
 				set_lock(piece, grid, false);
 				clear_piece_pointers(grid, piece);
 				piece->row_pos += num_empty_rows;
-				remove_from_dynamic_array(grid->locked_pieces, piece);
-
 			}
 			num_empty_rows++;
 			index = pieces_to_drop->size;

--- a/Falling Bricks/source/Main.c
+++ b/Falling Bricks/source/Main.c
@@ -8,6 +8,11 @@
 #include "Paths.h"
 #include "Game.h"
 
+#ifdef _DEBUG
+	#define _CRTDBG_MAP_ALLOC
+	#include <crtdbg.h>
+#endif
+
 // For browser support
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
@@ -81,6 +86,10 @@ void main_loop() {
 
 int main(int argc, char* args[]) {
 	srand(time(NULL));
+#ifdef _DEBUG
+	// Enable memory leak checks only in debug builds
+	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+#endif
 
 	game_is_running = init_window(&window, &renderer) && setup();
 


### PR DESCRIPTION
Fixed memory leak during line clearing
Adjusted drop algorithm to guarantee all pieces can drop

This pull request introduces enhancements to the `Falling Bricks` game code, focusing on improving the piece-dropping logic in the grid and adding debug utilities for memory leak detection. The key changes include refining the `drop_all_pieces` function to handle edge cases more effectively and enabling memory leak checks in debug builds.

### Improvements to piece-dropping logic:
* Modified the `drop_all_pieces` function in `Grid.c` to include a `while` loop that ensures pieces continue to drop if their position can be further adjusted after other pieces have moved. This handles rare edge cases where cascading drops are possible.
* Removed redundant code that previously removed pieces from the dynamic array during the drop operation, simplifying the logic. ( and gets rid of memory leak)

### Debugging enhancements:
* Added conditional compilation for memory leak detection in `Main.c`. When `_DEBUG` is defined, memory allocations are tracked, and leak checks are performed at program termination. [[1]](diffhunk://#diff-2fb9310b42db3f1181266ac3b1cb684f4759e3ee23b679b40784e4f24278be18R11-R15) [[2]](diffhunk://#diff-2fb9310b42db3f1181266ac3b1cb684f4759e3ee23b679b40784e4f24278be18R89-R92)